### PR TITLE
Ordena cidades

### DIFF
--- a/db/mongo.go
+++ b/db/mongo.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -66,9 +67,9 @@ func (c *Client) GetCities(state string) ([]string, error) {
 	var location descritor.Location
 	filter := bson.M{"state": state}
 	if err := c.client.Database(c.dbName).Collection(descritor.LocationsCollection).FindOne(ctx, filter).Decode(&location); err != nil {
-
 		return nil, exception.New(exception.NotFound, fmt.Sprintf("Falha ao buscar estados disponíveis do banco na collection [%s], erro %q", descritor.LocationsCollection, err), nil)
 	}
+	sort.Strings(location.Cities) // TODO get it sorted from MongoDB?
 	return location.Cities, nil
 }
 


### PR DESCRIPTION
Reparei que a lista de cidades está aparecendo de forma não ordenada, e acho que seria legal ter as cidades em ordem alfabética, né?

Não sei se faz sentido fazer isso no Go, mas pelo o que eu entendi, o _array_ já está no Mongo assim, então uma solução seria ordenar depois da _query_ no banco de dados. Mas se tiver como embutir isso na _query_, ou já salvar as cidades ordenas, deve ficar melhor, né?

O que acha?