### PR TITLE
Remove HTML tags from error and success message

### DIFF
--- a/atualizar_candidatura_handler.go
+++ b/atualizar_candidatura_handler.go
@@ -110,7 +110,7 @@ func newAtualizarCandidaturaFormHandler(dbClient *db.Client, year int) echo.Hand
 			})
 		}
 		return c.Render(http.StatusOK, "atualizar-candidato-success.html", map[string]interface{}{
-			"ErrorMsg":     "<strong>Seus dados foram atualizados com sucesso!</strong>",
+			"ErrorMsg":     "Seus dados foram atualizados com sucesso!",
 			"Success":      true,
 			"Year":         year,
 			"SequentialID": candidate.SequencialCandidate,

--- a/soucandidato_handler.go
+++ b/soucandidato_handler.go
@@ -46,7 +46,7 @@ func login(db *db.Client, tokenService *token.Token, emailClient *email.Client, 
 		log.Printf("failed to sending email (%s):%q", email, err)
 		return "Erro inesperado. Por favor tentar novamente mais tarde."
 	}
-	return fmt.Sprintf("Email com código de acesso enviado para <strong>%s</strong>. Verifique sua caixa de spam caso não encontre.", email)
+	return fmt.Sprintf("Email com código de acesso enviado para %s. Verifique sua caixa de spam caso não encontre.", email)
 }
 
 func souCandidatoGET(c echo.Context) error {


### PR DESCRIPTION
### Removed

- Remove as tags HTML dentro das mensagens vindas dos handlers. Outra forma de fazer isso seria não "escapar" o HTML e deixar renderiza, mas não acho seguro. A melhor forma mesmo, IMO, é remover as tags dessas mensagens e deixar só o texto.

---

closes #48 