### PR TITLE
Dobra tamanho da foto do candidato

### DIFF
--- a/web/templates/candidato.html
+++ b/web/templates/candidato.html
@@ -31,7 +31,7 @@
 
             <div class="row">
                 <div class="col-12 col-md-6 mx-auto">
-                    <img class="card-img-top d-block img-fluid w-25 mx-auto my-2" src="{{.Candidato.PhotoURL}}"
+                    <img class="card-img-top d-block img-fluid w-50 mx-auto my-2" src="{{.Candidato.PhotoURL}}"
                         alt="Foto de {{.Candidato.Name}}" />
                 </div>
             </div>


### PR DESCRIPTION
Acredito que o tamanho atual da foto está muito pequeno para exibição, dificultando a identificação imediata do candidato. Proponho dobrar a largura.