### PR TITLE
Aumentando número de pautas e tamanho das propostas

### DIFF
--- a/atualizar_candidatura_handler.go
+++ b/atualizar_candidatura_handler.go
@@ -16,16 +16,14 @@ import (
 )
 
 const (
-	maxBiographyTextSize     = 500
-	maxProposalsTextSize     = 100
-	maxProposalsPerCandidate = 5
-	maxTagsSize              = 4
-	maxProposals             = 5
-	maxContactsTextSize      = 100
-	numTagsFieldName         = "numTags"
-	bioFieldName             = "biography"
-	contactFieldName         = "contact"
-	providerFieldName        = "provider"
+	maxBiographyTextSize = 500
+	maxProposalsTextSize = 280
+	maxProposals         = 10
+	maxContactsTextSize  = 100
+	numTagsFieldName     = "numTags"
+	bioFieldName         = "biography"
+	contactFieldName     = "contact"
+	providerFieldName    = "provider"
 )
 
 type atualizarCandidaturaParams struct {
@@ -264,11 +262,12 @@ func newAtualizarCandidaturaHandler(dbClient *db.Client, tags []string) echo.Han
 			})
 		}
 		r := c.Render(http.StatusOK, "atualizar-candidato.html", map[string]interface{}{
-			"Token":          encodedAccessToken,
-			"AllTags":        tags,
-			"Candidato":      foundCandidate,
-			"MaxProposals":   maxProposals,
-			"SocialNetworks": socialNetworksUI,
+			"Token":                encodedAccessToken,
+			"AllTags":              tags,
+			"Candidato":            foundCandidate,
+			"MaxProposals":         maxProposals,
+			"MaxProposalsTextSize": maxProposalsTextSize,
+			"SocialNetworks":       socialNetworksUI,
 		})
 		fmt.Println(r)
 		return r

--- a/web/templates/atualizar-candidato.html
+++ b/web/templates/atualizar-candidato.html
@@ -131,7 +131,7 @@
     function subjectsComponent() {
         return {
             maxSubjects: {{.MaxProposals}},
-            maxDescriptionLength: 100,
+            maxDescriptionLength: {{.maxProposalsTextSize}},
             allSubjects: [
                 {{range .AllTags}}"{{.}}",{{end}}
             ],

--- a/web/templates/atualizar-candidato.html
+++ b/web/templates/atualizar-candidato.html
@@ -131,7 +131,7 @@
     function subjectsComponent() {
         return {
             maxSubjects: {{.MaxProposals}},
-            maxDescriptionLength: {{.maxProposalsTextSize}},
+            maxDescriptionLength: {{.MaxProposalsTextSize}},
             allSubjects: [
                 {{range .AllTags}}"{{.}}",{{end}}
             ],


### PR DESCRIPTION
Aumentando o número de pautas máximo para 10 e o tamanho das propostas associadas a cada pauta para 280.

Fix #134 